### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 # .github/workflows/test.yml
 name: 🧪 Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TheBrickalista/Test-Drive/security/code-scanning/1](https://github.com/TheBrickalista/Test-Drive/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow is primarily focused on testing and does not appear to require write access to repository contents or other resources, the permissions can be set to `contents: read`. This ensures that the workflow has only the minimal access required to perform its tasks.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. This change will limit the permissions of the `GITHUB_TOKEN` and adhere to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
