### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: 🚀 Publish to PyPI
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/TheBrickalista/Test-Drive/security/code-scanning/2](https://github.com/TheBrickalista/Test-Drive/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the tasks in the workflow, the `contents: read` permission is sufficient for checking out the code, and no additional permissions are needed for the other steps, as they rely on external tools and secrets (e.g., `PYPI_TOKEN`) for authentication.

The `permissions` block will be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
