### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 # .github/workflows/publish.yml
 name: 📦 Publish Python Package
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/TheBrickalista/Test-Drive/security/code-scanning/3](https://github.com/TheBrickalista/Test-Drive/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow involves publishing a Python package to PyPI and does not appear to interact with repository contents or GitHub features like pull requests, we will set `contents: read` as the minimal permission. This ensures that the workflow can read repository contents if needed but cannot modify them.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
